### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
           fetch-depth: '0'
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ github.token }}
           fetch-depth: '0'
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
       - run: |
@@ -49,4 +49,4 @@ jobs:
           tar -xvf terraform-docs*.tar.gz --directory "$GITHUB_WORKSPACE/bin"
           chmod +x "$GITHUB_WORKSPACE/bin/terraform-docs"
           echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
-      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,9 +19,9 @@ jobs:
   terraform:
     runs-on: ubuntu-latest
     steps:
-      - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.branch }}
           token: ${{ github.token }}
@@ -31,7 +31,7 @@ jobs:
           echo "plugin_cache_dir=$HOME/.terraform.d/plugin-cache" >~/.terraformrc
           mkdir --parents ~/.terraform.d/plugin-cache
       - name: Cache Terraform
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.terraform.d/plugin-cache
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.branch }}
           token: ${{ github.token }}
           fetch-depth: '0'
-      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
       - run: |
@@ -68,17 +68,17 @@ jobs:
           tar -xvf terraform-docs*.tar.gz --directory "$GITHUB_WORKSPACE/bin"
           chmod +x "$GITHUB_WORKSPACE/bin/terraform-docs"
           echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
-      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   version:
     permissions: write-all
     name: versioning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: '0'
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@a2c70ae13a881faf2b4953baaa9e49731997ab36 # 1.67.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
             - --allow-missing-credentials
         - id: detect-private-key
       repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: c4a0b883114b00d8d76b479c820ce7950211c99b
+      rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     - hooks:
         - id: forbid-tabs
           exclude: binary|\.bin$
@@ -28,30 +28,30 @@ repos:
             - makefile
             - xml
       repo: https://github.com/Lucas-C/pre-commit-hooks
-      rev: 762c66ea96843b54b936fc680162ea67f85ec2d7
+      rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8 # v1.5.6
     - hooks:
         - id: shell-lint
           exclude: template|\.template$
       repo: https://github.com/jameswoolfenden/pre-commit-shell
-      rev: 062f0b028ae65827e04f91c1e6738cfcbe9b337f
+      rev: 062f0b028ae65827e04f91c1e6738cfcbe9b337f # v1.0.6
     - hooks:
         - id: markdownlint
       repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: 3f18b949d53ffddafc6d98373366533d61e00da8
+      rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e # v0.48.0
     - hooks:
         - id: terraform-fmt
           language_version: python3.11
         - id: tf2docs
           language_version: python3.11
       repo: https://github.com/jameswoolfenden/pre-commit
-      rev: b00d945c0dce54f230a5d1cfb7d24e285396e1f2
+      rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
     - hooks:
         - id: checkov
           entry: checkov -d example/examplea --external-checks-dir checkov --download-external-modules true --compact
           files: .
           verbose: true
       repo: https://github.com/bridgecrewio/checkov
-      rev: 3.1.20
+      rev: e52a901a3829d818d20c9b75e544845c8b756968 # 3.2.526
     - hooks:
         - id: pike-docs-go
           args:
@@ -60,7 +60,7 @@ repos:
             - .
             - -i
       repo: https://github.com/jameswoolfenden/pike
-      rev: 7819c4cf53a0dfe9dcbc06e5c723b7c3d620cb27
+      rev: d043242b9e1733e9e5a67c20bb87c05a4d563596 # v0.4.1
     - hooks:
         - id: ghat-go
           args:
@@ -73,4 +73,4 @@ repos:
             - -d
             - .
       repo: https://github.com/jameswoolfenden/ghat
-      rev: 901045b73e704af4b4188005619ffc0f9b669154
+      rev: 9ac03a27b221b0173a40e66aac1d09f5be4db40c # v0.1.23

--- a/example/examplea/terraform.tf
+++ b/example/examplea/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "5.13.1"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 1.3.5"


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.